### PR TITLE
Run only as long as requested

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -477,7 +477,10 @@ int main(int argc, char * argv[]) {
            total_runtime);
   }
 
-  for (int i=0; i< numberOfCgSets; ++i) {
+  // Only run as long as requested. Conversely, if card performance increases this
+  // will ensure test runs at least as long as requested.
+  while ( total_runtime > times[0] ) 
+  {
     HIPZeroVector(x); // Zero out x
     ierr = CG( A, data, b, x, optMaxIters, optTolerance, niters, normr, normr0, &times[0], true, false);
     if (ierr) HPCG_fout << "Error in call to CG: " << ierr << ".\n" << endl;


### PR DESCRIPTION
Possibly can remove additional code ( ie. numberCgSets ).

This change increases the chances to produce a 'valid' (ie. >1800 second ) run on cards with inconsistent performance.
- For cards whose performance decreases over time few CgSets must be run to run a full 1800 seconds.
- For cards whose performance increases over time this change ensures the full requested time is completed.